### PR TITLE
Enforce line-ending style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-.licenses/** -diff linguist-generated=true
+* text=auto eol=lf
+
+dist/** -diff linguist-generated=true


### PR DESCRIPTION
This PR enforces LF line endings to prevent possible issues with `ncc build` outputting different results based on platform.