### PR TITLE
Fix sourcemap and add licensed

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,0 +1,74 @@
+# This workflow checks the statuses of cached dependencies used in this action
+# with the help of the Licensed tool. If any licenses are invalid or missing,
+# this workflow will fail. See: https://github.com/licensee/licensed
+
+name: Licensed
+
+on:
+  # Uncomment the below lines to run this workflow on pull requests and pushes
+  # to the default branch. This is useful for checking licenses before merging
+  # changes into the default branch.
+  # pull_request:
+  #   branches:
+  #     - main
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  licensed:
+    name: Check Licenses
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        id: npm-ci
+        run: npm ci
+
+      - name: Setup Ruby
+        id: setup-ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+
+      - uses: github/setup-licensed@v1
+        with:
+          version: 4.x
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # If this is a workflow_dispatch event, update the cached licenses.
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        name: Update Licenses
+        id: update-licenses
+        run: licensed cache
+
+      # Then, commit the updated licenses to the repository.
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        name: Commit Licenses
+        id: commit-licenses
+        run: |
+          git config --local user.email "licensed-ci@users.noreply.github.com"
+          git config --local user.name "licensed-ci"
+          git add .
+          git commit -m "Auto-update license files"
+          git push
+
+      # Last, check the status of the cached licenses.
+      - name: Check Licenses
+        id: check-licenses
+        run: licensed status

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,3 +1,5 @@
+# See: https://github.com/licensee/licensed/blob/main/docs/configuration.md
+
 sources:
   npm: true
 
@@ -8,9 +10,9 @@ allowed:
   - isc
   - mit
   - cc0-1.0
-  - unlicense
-  - 0bsd
+  - other
 
-reviewed:
+ignored:
   npm:
-    - sax
+    # Used by Rollup.js when building in GitHub Actions
+    - '@rollup/rollup-linux-x64-gnu'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .DS_Store
+.licenses/
 dist/
 node_modules/
 coverage/

--- a/.yaml-lint.yml
+++ b/.yaml-lint.yml
@@ -10,3 +10,5 @@ rules:
     max: 80
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true
+ignore:
+  - .licenses/

--- a/README.md
+++ b/README.md
@@ -71,3 +71,48 @@ For example workflow runs, check out the
 | Output | Description             |
 | ------ | ----------------------- |
 | `time` | The time we greeted you |
+
+## Dependency License Management
+
+This template includes a GitHub Actions workflow,
+[`licensed.yml`](./.github/workflows/licensed.yml), that uses
+[Licensed](https://github.com/licensee/licensed) to check for dependencies with
+missing or non-compliant licenses. This workflow is initially disabled. To
+enable the workflow, follow the below steps.
+
+1. Open [`licensed.yml`](./.github/workflows/licensed.yml)
+1. Uncomment the following lines:
+
+   ```yaml
+   # pull_request:
+   #   branches:
+   #     - main
+   # push:
+   #   branches:
+   #     - main
+   ```
+
+1. Save and commit the changes
+
+Once complete, this workflow will run any time a pull request is created or
+changes pushed directly to `main`. If the workflow detects any dependencies with
+missing or non-compliant licenses, it will fail the workflow and provide details
+on the issue(s) found.
+
+### Updating Licenses
+
+Whenever you install or update dependencies, you can use the Licensed CLI to
+update the licenses database. To install Licensed, see the project's
+[Readme](https://github.com/licensee/licensed?tab=readme-ov-file#installation).
+
+To update the cached licenses, run the following command:
+
+```bash
+licensed cache
+```
+
+To check the status of cached licenses, run the following command:
+
+```bash
+licensed status
+```

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ const config = {
     format: 'es',
     sourcemap: false
   },
-  plugins: [commonjs(), nodeResolve()]
+  plugins: [commonjs(), nodeResolve({ preferBuiltins: true })]
 }
 
 export default config


### PR DESCRIPTION
This PR fixes sourcemap generation to remove the warning about the Rollup 'sourcemap' option.

It also adds an example workflow for caching and validating dependency licenses using [licensed](https://github.com/licensee/licensed), as well as instructions on how to enable the workflow and use licensed locally.