### PR TITLE
Replace deprecated action

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           ruby-version: ruby
 
-      - uses: github/setup-licensed@v1
+      - uses: licensee/setup-licensed@v1.3.2
         with:
           version: 4.x
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Action [`github/setup-licensed`](https://github.com/github/setup-licensed) has been deprecated since 7 February 2025 in favor of [`licensee/setup-licensed`](https://github.com/licensee/setup-licensed)